### PR TITLE
Delete src/mathdistops directory

### DIFF
--- a/src/mathdistops/__init__.py
+++ b/src/mathdistops/__init__.py
@@ -1,3 +1,0 @@
-# read version from installed package
-from importlib.metadata import version
-__version__ = version("mathdistops")


### PR DESCRIPTION
Due to having two __init__ based folders (MathDistOps and mathdistops). There will be an issue when cloning the repository from scratch.

"warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:"

Propose to only retain MathDistOps.