### PR TITLE
done with qnorm

### DIFF
--- a/src/mathdistops/qnorm.py
+++ b/src/mathdistops/qnorm.py
@@ -1,8 +1,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.special import erfinv
+import scipy.stats as stats
+import math
+import altair as alt
+import pandas as pd
 
-def qnorm(p, mean=0, std_dev=1, plot_graph=True):
+def qnorm(p, mean=0, std_dev=1, graph=True):
     """
     Quantile (Inverse Cumulative Distribution Function) of the normal distribution.
 
@@ -15,7 +19,7 @@ def qnorm(p, mean=0, std_dev=1, plot_graph=True):
     std_dev: float, optional
         The standard deviation of the normal distribution. Default is 1.
     plot_graph: bool, optional
-        Whether to plot the quantile graph. Default is True.
+        Whether to plot the PDF and CDF graphs. Default is True.
 
     Returns
     -------
@@ -32,15 +36,14 @@ def qnorm(p, mean=0, std_dev=1, plot_graph=True):
     falls. It is characterized by the mean (`μ`) and standard deviation (`σ`), determining
     the center and spread of the distribution.
 
+    The CDF describes the probability that a random variable in a normal distribution
+    is less than or equal to a specified value `x`. It is characterized by the mean (`μ`)
+    and standard deviation (`σ`), determining the center and spread of the distribution.
+
     Example
     -------
     >>> qnorm(0.8413447460685429, mean=0, std_dev=1)
     1.0
-
-    Graph
-    -----
-    The blue curve represents the normal distribution quantile for the given parameters.
-    The horizontal red line corresponds to the specified probability `p`.
 
     Notes
     -----
@@ -48,5 +51,75 @@ def qnorm(p, mean=0, std_dev=1, plot_graph=True):
     application may lead to undefined values or errors for extreme probabilities.
 
     """
+    
+    # if p is None:
+    #     raise ValueError("Parameter 'p' is required.")
 
-    pass 
+    if p<0 or p>1:
+        raise ValueError("Parameter 'p' stands for probability, which should have a value between 0 and 1 only.")
+
+    if std_dev <= 0:
+        raise ValueError("Standard deviation cannot be zero or negative.")
+
+    if not all(isinstance(param, (int, float)) for param in [p, mean, std_dev]):
+        raise TypeError("Input parameters must be numerical.")
+
+    # Q(p; μ, σ) = μ + σ * sqrt(2) * erfinv(2p - 1)
+
+    #Calculate quantile
+    q = mean + std_dev * math.sqrt(2) * erfinv(2*p - 1)
+
+    # Standardizing the names
+    x = q 
+    z = (x - mean) / std_dev
+    prob = p
+    
+    results_df = pd.DataFrame({'Quantile': [q]})
+    
+    x_values = np.linspace(mean - 3 * std_dev, mean + 3 * std_dev, 100)
+    y_values_pdf = stats.norm.pdf(x_values, mean, std_dev)
+    y_values_cdf = stats.norm.cdf(x_values, mean, std_dev)
+    data = {'x': x_values, 'pdf': y_values_pdf, 'cdf': y_values_cdf, 'q': q}
+    df = pd.DataFrame(data)
+    
+    # PDF
+    chart = alt.Chart(df).mark_line().encode(
+        x='x',
+        y='pdf'
+    )
+    
+    #Add a shaded area under the curve ()
+    shade_area = alt.Chart(df, title=f"Probability Density Function for p = {prob}, mean = {mean}, sd = {std_dev}").mark_area(opacity=0.3, color='lightblue').encode(
+        x=alt.X('x', title='X'),
+        y=alt.Y('pdf', title='f(X)')
+    ).transform_filter(
+        alt.datum.x <= x  
+    )
+    
+    # Add vertical line at respective quantile 
+    vertline = alt.Chart(pd.DataFrame({'z': [q]})).mark_rule(strokeDash=[3, 3]).encode(
+        x='z'
+    )
+    #CDF
+    cdf_chart = alt.Chart(df, title=f"Cumulative Distribution Chart for p = {prob}, mean = {mean}, sd = {std_dev}").mark_line().encode(
+        x=alt.X('x').title("x"),
+        y=alt.Y('cdf').title('probability'),
+        color=alt.value('orange'),
+        opacity=alt.value(0.5),
+    ).properties(
+        width=300,
+        height=150
+    )
+
+    horizontalline = alt.Chart(pd.DataFrame({'p': [prob]})).mark_rule(strokeDash=[3, 3]).encode(
+        y='p'
+    )
+    
+    # Combine all plots
+    result_graph = (shade_area + chart + vertline) |(cdf_chart + vertline + horizontalline)
+
+    if graph == True: 
+        return results_df, result_graph
+    else:
+        return results_df
+    

--- a/src/mathdistops/qnorm.py
+++ b/src/mathdistops/qnorm.py
@@ -52,8 +52,8 @@ def qnorm(p, mean=0, std_dev=1, graph=True):
 
     """
     
-    # if p is None:
-    #     raise ValueError("Parameter 'p' is required.")
+    if p is None:
+        raise ValueError("Parameter 'p' is required.")
 
     if p<0 or p>1:
         raise ValueError("Parameter 'p' stands for probability, which should have a value between 0 and 1 only.")

--- a/tests/test_qnorm.py
+++ b/tests/test_qnorm.py
@@ -53,6 +53,10 @@ def test_nonsensical_input():
         results = qnorm('hi', mean=5, std_dev=2, graph=False)
     assert str(custom_string.value), "Input parameters must be numerical."
 
+    with pytest.raises(ValueError) as custom_string:
+        results = qnorm(None)
+    assert str(custom_string.value), "Parameter 'p' is required."
+
 
 
 

--- a/tests/test_qnorm.py
+++ b/tests/test_qnorm.py
@@ -1,0 +1,58 @@
+from mathdistops.qnorm import qnorm
+import pytest
+import pandas as pd
+import altair as alt
+
+def test_output_datatype():
+    """
+    Tests whether function returns correct output data objects.
+    """
+    results, graph = qnorm(0.7, mean=2, std_dev=3)
+    assert isinstance(results, pd.DataFrame)
+    assert hasattr(graph, 'hconcat')
+    assert len(graph.hconcat) == 2
+
+def test_df_results():
+    """
+    Tests whether function calculates quantile value correctly.
+    """
+    results = qnorm(0.5, graph=False)
+    assert results.shape == (1, 1)
+    assert results['Quantile'].iloc[0] == 0
+
+    results_df = qnorm(0.25, graph=False)
+    assert abs(results_df['Quantile'].iloc[0] - (-0.67449)) <= 0.001
+
+def test_missing_input():
+    """
+    Test case for TypeError when parameter `p` is missing.
+    """
+    with pytest.raises(TypeError) as custom_string:
+        results, graph = qnorm()
+    assert str(custom_string.value) ==  "qnorm() missing 1 required positional argument: 'p'"
+
+
+def test_p_outofrange():
+    """
+    Test case for ValueError when parameter `p` is out of range.
+    """
+    with pytest.raises(ValueError) as custom_string:
+        results, graph = qnorm(5)
+    assert str(custom_string.value) == "Parameter 'p' stands for probability, which should have a value between 0 and 1 only."
+    
+
+def test_nonsensical_input():
+    """
+    Test case for ValueError and Type Error in case of incorrect user input, e.g. negative standard deviation or non numerical value.
+    """
+    with pytest.raises(ValueError) as custom_string:
+        results = qnorm(0.3, mean=5, std_dev=-2, graph=False)
+    assert str(custom_string.value) == "Standard deviation cannot be zero or negative."
+
+    with pytest.raises(TypeError) as custom_string:
+        results = qnorm('hi', mean=5, std_dev=2, graph=False)
+    assert str(custom_string.value), "Input parameters must be numerical."
+
+
+
+


### PR DESCRIPTION
Done both tests and functions. 

For edge cases, I would recommend to remove this part:
if q is None:
        raise ValueError("Parameter 'q' is required.")
-> Because it is quite weird to define a function with None as input and set it to fail...
So we use the tests to capture for TypeError instead. 

Other than that, for qnorm, the input p value also has to be between 0 and 1.          
    